### PR TITLE
Fix FTBQuests

### DIFF
--- a/common/src/main/resources/data/itemfilters/tags/items/check_nbt.json
+++ b/common/src/main/resources/data/itemfilters/tags/items/check_nbt.json
@@ -1,0 +1,6 @@
+{
+	"replace": false,
+	"values": [
+		"custommachinery:custom_machine_item"
+	]
+}


### PR DESCRIPTION
Add itemfilters:check_nbt tag to custom_machine item, fixing the issue where FTBQuests would recognize all machines as one.