### PR TITLE
Fix auto-input voiding energy of the neighbor energy storage

### DIFF
--- a/forge/src/main/java/fr/frinn/custommachinery/forge/transfer/ForgeEnergyHandler.java
+++ b/forge/src/main/java/fr/frinn/custommachinery/forge/transfer/ForgeEnergyHandler.java
@@ -95,7 +95,7 @@ public class ForgeEnergyHandler implements ICommonEnergyHandler {
         if(maxExtracted > 0) {
             int maxInserted = to.receiveEnergy(maxExtracted, true);
             if(maxInserted > 0) {
-                from.extractEnergy(maxAmount, false);
+                from.extractEnergy(maxInserted, false);
                 to.receiveEnergy(maxExtracted, false);
             }
         }


### PR DESCRIPTION
## Description

When auto-input is enabled, the machine will void all energy from the neighbor energy storage.

## Cause

Currently, `ForgeEnergyHandler` extracts everything the neighbor energy storage can provide, instead of extracting precisely the amount a machine can except.
We know how much energy a machine can accept according to `maxInserted`, so we should extract exactly that amount instead of `maxAmount`, which is `Integer.MAX_VALUE` and makes neighbor energy storage extract virtually everything into the void.