### PR TITLE
Allow adding items/blocks from other mods in catalysts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url = 'https://repo.spongepowered.org/repository/maven-public/' }
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '4.1+', changing: true
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '6+', changing: true
         classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
     }
 }
@@ -163,7 +163,7 @@ repositories {
     }
     maven { // TOP
         name = "tterrag maven"
-        url = "http://maven.tterrag.com/"
+        url = "https://maven.tterrag.com/"
     }
     maven { //Cursemaven
         name = "Curse maven"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/fr/frinn/custommachinery/client/ClientHandler.java
+++ b/src/main/java/fr/frinn/custommachinery/client/ClientHandler.java
@@ -118,9 +118,10 @@ public class ClientHandler {
     public static void registerItemColors(final ColorHandlerEvent.Item event) {
         event.getItemColors().register((stack, tintIndex) -> {
             BlockState state = Registration.CUSTOM_MACHINE_BLOCK.get().getDefaultState();
-            World world = Minecraft.getInstance().world;
-            BlockPos pos = Minecraft.getInstance().player.getPosition();
-            return Minecraft.getInstance().getBlockColors().getColor(state, world, pos, tintIndex);
+            Minecraft instance = Minecraft.getInstance();
+            World world = instance.world;
+            BlockPos pos = instance.player.getPosition();
+            return instance.getBlockColors().getColor(state, world, pos, tintIndex);
         }, Registration.CUSTOM_MACHINE_ITEM::get);
     }
 
@@ -212,50 +213,51 @@ public class ClientHandler {
 
     @SuppressWarnings("deprecation")
     public static void renderItemOverlayIntoGUI(MatrixStack matrix, FontRenderer fr, ItemStack stack, int xPosition, int yPosition, @Nullable String text) {
-        if (!stack.isEmpty()) {
-            if (stack.getCount() != 1 || text != null) {
-                matrix.push();
-                String s = text == null ? String.valueOf(stack.getCount()) : text;
-                matrix.translate(0.0D, 0.0D, Minecraft.getInstance().getItemRenderer().zLevel + 200.0F);
-                IRenderTypeBuffer.Impl irendertypebuffer$impl = IRenderTypeBuffer.getImpl(Tessellator.getInstance().getBuffer());
-                fr.renderString(s, (float)(xPosition + 19 - 2 - fr.getStringWidth(s)), (float)(yPosition + 6 + 3), 16777215, true, matrix.getLast().getMatrix(), irendertypebuffer$impl, false, 0, 15728880);
-                irendertypebuffer$impl.finish();
-                RenderSystem.enableDepthTest();
-                matrix.pop();
-            }
+        if (stack.isEmpty()) {
+            return;
+        }
+        if (stack.getCount() != 1 || text != null) {
+            matrix.push();
+            String s = text == null ? String.valueOf(stack.getCount()) : text;
+            matrix.translate(0.0D, 0.0D, Minecraft.getInstance().getItemRenderer().zLevel + 200.0F);
+            IRenderTypeBuffer.Impl irendertypebuffer$impl = IRenderTypeBuffer.getImpl(Tessellator.getInstance().getBuffer());
+            fr.renderString(s, (float)(xPosition + 19 - 2 - fr.getStringWidth(s)), (float)(yPosition + 6 + 3), 16777215, true, matrix.getLast().getMatrix(), irendertypebuffer$impl, false, 0, 15728880);
+            irendertypebuffer$impl.finish();
+            RenderSystem.enableDepthTest();
+            matrix.pop();
+        }
 
-            if (stack.getItem().showDurabilityBar(stack)) {
-                RenderSystem.disableDepthTest();
-                RenderSystem.disableTexture();
-                RenderSystem.disableAlphaTest();
-                RenderSystem.disableBlend();
-                Tessellator tessellator = Tessellator.getInstance();
-                BufferBuilder bufferbuilder = tessellator.getBuffer();
-                double health = stack.getItem().getDurabilityForDisplay(stack);
-                int i = Math.round(13.0F - (float)health * 13.0F);
-                int j = stack.getItem().getRGBDurabilityForDisplay(stack);
-                draw(bufferbuilder, xPosition + 2, yPosition + 13, 13, 2, 0, 0, 0, 255);
-                draw(bufferbuilder, xPosition + 2, yPosition + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
-                RenderSystem.enableBlend();
-                RenderSystem.enableAlphaTest();
-                RenderSystem.enableTexture();
-                RenderSystem.enableDepthTest();
-            }
+        if (stack.getItem().showDurabilityBar(stack)) {
+            RenderSystem.disableDepthTest();
+            RenderSystem.disableTexture();
+            RenderSystem.disableAlphaTest();
+            RenderSystem.disableBlend();
+            Tessellator tessellator = Tessellator.getInstance();
+            BufferBuilder bufferbuilder = tessellator.getBuffer();
+            double health = stack.getItem().getDurabilityForDisplay(stack);
+            int i = Math.round(13.0F - (float)health * 13.0F);
+            int j = stack.getItem().getRGBDurabilityForDisplay(stack);
+            draw(bufferbuilder, xPosition + 2, yPosition + 13, 13, 2, 0, 0, 0, 255);
+            draw(bufferbuilder, xPosition + 2, yPosition + 13, i, 1, j >> 16 & 255, j >> 8 & 255, j & 255, 255);
+            RenderSystem.enableBlend();
+            RenderSystem.enableAlphaTest();
+            RenderSystem.enableTexture();
+            RenderSystem.enableDepthTest();
+        }
 
-            ClientPlayerEntity clientplayerentity = Minecraft.getInstance().player;
-            float f3 = clientplayerentity == null ? 0.0F : clientplayerentity.getCooldownTracker().getCooldown(stack.getItem(), Minecraft.getInstance().getRenderPartialTicks());
-            if (f3 > 0.0F) {
-                RenderSystem.disableDepthTest();
-                RenderSystem.disableTexture();
-                RenderSystem.enableBlend();
-                RenderSystem.defaultBlendFunc();
-                Tessellator tessellator1 = Tessellator.getInstance();
-                BufferBuilder bufferbuilder1 = tessellator1.getBuffer();
-                draw(bufferbuilder1, xPosition, yPosition + MathHelper.floor(16.0F * (1.0F - f3)), 16, MathHelper.ceil(16.0F * f3), 255, 255, 255, 127);
-                RenderSystem.disableBlend();
-                RenderSystem.enableTexture();
-                RenderSystem.enableDepthTest();
-            }
+        ClientPlayerEntity clientPlayer = Minecraft.getInstance().player;
+        float cooldown = clientPlayer == null ? 0.0F : clientPlayer.getCooldownTracker().getCooldown(stack.getItem(), Minecraft.getInstance().getRenderPartialTicks());
+        if (cooldown > 0.0F) {
+            RenderSystem.disableDepthTest();
+            RenderSystem.disableTexture();
+            RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
+            Tessellator tessellator1 = Tessellator.getInstance();
+            BufferBuilder bufferbuilder1 = tessellator1.getBuffer();
+            draw(bufferbuilder1, xPosition, yPosition + MathHelper.floor(16.0F * (1.0F - cooldown)), 16, MathHelper.ceil(16.0F * cooldown), 255, 255, 255, 127);
+            RenderSystem.disableBlend();
+            RenderSystem.enableTexture();
+            RenderSystem.enableDepthTest();
         }
     }
 

--- a/src/main/java/fr/frinn/custommachinery/client/ClientPacketHandler.java
+++ b/src/main/java/fr/frinn/custommachinery/client/ClientPacketHandler.java
@@ -31,28 +31,30 @@ public class ClientPacketHandler {
     public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
     public static void handleCraftingManagerStatusChangedPacket(BlockPos pos, MachineStatus status) {
-        if(Minecraft.getInstance().world != null) {
-            TileEntity tile = Minecraft.getInstance().world.getTileEntity(pos);
+        Minecraft instance = Minecraft.getInstance();
+        if(instance.world != null) {
+            TileEntity tile = instance.world.getTileEntity(pos);
             if(tile instanceof CustomMachineTile) {
                 CustomMachineTile machineTile = (CustomMachineTile)tile;
                 CraftingManager manager = machineTile.craftingManager;
                 if(status != manager.getStatus()) {
                     manager.setStatus(status);
                     machineTile.requestModelDataUpdate();
-                    Minecraft.getInstance().world.notifyBlockUpdate(tile.getPos(), tile.getBlockState(), tile.getBlockState(), Constants.BlockFlags.RERENDER_MAIN_THREAD);
+                    instance.world.notifyBlockUpdate(tile.getPos(), tile.getBlockState(), tile.getBlockState(), Constants.BlockFlags.RERENDER_MAIN_THREAD);
                 }
             }
         }
     }
 
     public static void handleRefreshCustomMachineTilePacket(BlockPos pos, ResourceLocation machine) {
-        if(Minecraft.getInstance().world != null) {
-            TileEntity tile = Minecraft.getInstance().world.getTileEntity(pos);
+        Minecraft instance = Minecraft.getInstance();
+        if(instance.world != null) {
+            TileEntity tile = instance.world.getTileEntity(pos);
             if(tile instanceof CustomMachineTile) {
                 CustomMachineTile machineTile = (CustomMachineTile) tile;
                 machineTile.setId(machine);
                 machineTile.requestModelDataUpdate();
-                Minecraft.getInstance().world.notifyBlockUpdate(pos, machineTile.getBlockState(), machineTile.getBlockState(), Constants.BlockFlags.RERENDER_MAIN_THREAD);
+                instance.world.notifyBlockUpdate(pos, machineTile.getBlockState(), machineTile.getBlockState(), Constants.BlockFlags.RERENDER_MAIN_THREAD);
             }
         }
     }

--- a/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
+++ b/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
@@ -112,7 +112,7 @@ public class CustomMachineJEIPlugin implements IModPlugin {
             for (ResourceLocation catalyst : machine.getCatalysts()) {
                 if (CustomMachinery.MACHINES.containsKey(catalyst)) {
                     // recognize machine first to avoid changing existed behaviour
-                    if (catalyst.equals(id)) {
+                    if (!catalyst.equals(id)) {
                         registration.addRecipeCatalyst(CustomMachineItem.makeMachineItem(catalyst), id);
                     }
                 } else if (ForgeRegistries.ITEMS.containsKey(catalyst)) {

--- a/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
+++ b/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
@@ -9,6 +9,7 @@ import fr.frinn.custommachinery.common.data.gui.ProgressBarGuiElement;
 import fr.frinn.custommachinery.common.init.CustomMachineItem;
 import fr.frinn.custommachinery.common.init.Registration;
 import fr.frinn.custommachinery.common.integration.jei.energy.EnergyIngredientHelper;
+import fr.frinn.custommachinery.common.util.CMLogger;
 import fr.frinn.custommachinery.common.util.Comparators;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
@@ -116,6 +117,8 @@ public class CustomMachineJEIPlugin implements IModPlugin {
                     }
                 } else if (ForgeRegistries.ITEMS.containsKey(catalyst)) {
                     registration.addRecipeCatalyst(new ItemStack(ForgeRegistries.ITEMS.getValue(catalyst)), id);
+                } else {
+                    CMLogger.INSTANCE.warn("Invalid catalyst `%s` for machine `%s`", catalyst, machine.getId());
                 }
             }
         });

--- a/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
+++ b/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
@@ -90,7 +90,10 @@ public class CustomMachineJEIPlugin implements IModPlugin {
                 if(progress != null) {
                     int posX = progress.getX();
                     int posY = progress.getY();
-                    boolean invertAxis = progress.getEmptyTexture().equals(ProgressBarGuiElement.BASE_EMPTY_TEXTURE) && progress.getFilledTexture().equals(ProgressBarGuiElement.BASE_FILLED_TEXTURE) && progress.getDirection() != ProgressBarGuiElement.Direction.RIGHT && progress.getDirection() != ProgressBarGuiElement.Direction.LEFT;
+                    boolean invertAxis = progress.getEmptyTexture().equals(ProgressBarGuiElement.BASE_EMPTY_TEXTURE)
+                                         && progress.getFilledTexture().equals(ProgressBarGuiElement.BASE_FILLED_TEXTURE)
+                                         && progress.getDirection() != ProgressBarGuiElement.Direction.RIGHT
+                                         && progress.getDirection() != ProgressBarGuiElement.Direction.LEFT;
                     int width = invertAxis ? progress.getHeight() : progress.getWidth();
                     int height = invertAxis ? progress.getWidth() : progress.getHeight();
                     return Collections.singleton(IGuiClickableArea.createBasic(posX, posY, width, height, screen.getMachine().getId()));

--- a/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
+++ b/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
@@ -115,7 +115,7 @@ public class CustomMachineJEIPlugin implements IModPlugin {
                         registration.addRecipeCatalyst(CustomMachineItem.makeMachineItem(catalyst), id);
                     }
                 } else if (ForgeRegistries.ITEMS.containsKey(catalyst)) {
-                    registration.addRecipeCatalyst(catalyst, id);
+                    registration.addRecipeCatalyst(new ItemStack(ForgeRegistries.ITEMS.getValue(catalyst)), id);
                 }
             }
         });

--- a/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
+++ b/src/main/java/fr/frinn/custommachinery/common/integration/jei/CustomMachineJEIPlugin.java
@@ -27,6 +27,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
@@ -107,7 +108,16 @@ public class CustomMachineJEIPlugin implements IModPlugin {
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         CustomMachinery.MACHINES.forEach((id, machine) -> {
             registration.addRecipeCatalyst(CustomMachineItem.makeMachineItem(id), id);
-            machine.getCatalysts().stream().filter(catalyst -> CustomMachinery.MACHINES.containsKey(catalyst) && !catalyst.equals(id)).forEach(catalyst -> registration.addRecipeCatalyst(CustomMachineItem.makeMachineItem(catalyst), id));
+            for (ResourceLocation catalyst : machine.getCatalysts()) {
+                if (CustomMachinery.MACHINES.containsKey(catalyst)) {
+                    // recognize machine first to avoid changing existed behaviour
+                    if (catalyst.equals(id)) {
+                        registration.addRecipeCatalyst(CustomMachineItem.makeMachineItem(catalyst), id);
+                    }
+                } else if (ForgeRegistries.ITEMS.containsKey(catalyst)) {
+                    registration.addRecipeCatalyst(catalyst, id);
+                }
+            }
         });
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/common/integration/kubejs/function/MachineJS.java
+++ b/src/main/java/fr/frinn/custommachinery/common/integration/kubejs/function/MachineJS.java
@@ -2,7 +2,6 @@ package fr.frinn.custommachinery.common.integration.kubejs.function;
 
 import dev.latvian.kubejs.fluid.EmptyFluidStackJS;
 import dev.latvian.kubejs.fluid.FluidStackJS;
-import dev.latvian.kubejs.item.EmptyItemStackJS;
 import dev.latvian.kubejs.item.ItemStackJS;
 import fr.frinn.custommachinery.common.data.component.EnergyMachineComponent;
 import fr.frinn.custommachinery.common.data.component.FluidMachineComponent;
@@ -96,7 +95,7 @@ public class MachineJS {
         return this.internal.componentManager.getComponentHandler(Registration.ITEM_MACHINE_COMPONENT.get())
                 .flatMap(handler -> handler.getComponentForID(slot))
                 .map(component -> ItemStackJS.of(component.getItemStack()))
-                .orElse(EmptyItemStackJS.INSTANCE);
+                .orElse(ItemStackJS.EMPTY);
     }
 
     public int getItemCapacity(String slot) {
@@ -118,7 +117,7 @@ public class MachineJS {
                     if(!simulate)
                         component.insert(stack);
                     if(maxInsert >= stack.getCount())
-                        return EmptyItemStackJS.INSTANCE;
+                        return ItemStackJS.EMPTY;
                     else
                         return ItemStackJS.of(Utils.makeItemStack(stack.getItem(), stack.getCount() - maxInsert, stack.getTag()));
                 })
@@ -131,7 +130,7 @@ public class MachineJS {
                 .flatMap(handler -> handler.getComponentForID(slot))
                 .map(component -> {
                     if(component.getItemStack().isEmpty())
-                        return EmptyItemStackJS.INSTANCE;
+                        return ItemStackJS.EMPTY;
                     int maxRemove = Math.min(toRemove, component.getItemStack().getCount());
                     ItemStack extracted = component.getItemStack().copy();
                     extracted.setCount(component.getItemStack().getCount() - maxRemove);
@@ -139,6 +138,6 @@ public class MachineJS {
                         component.extract(maxRemove);
                     return ItemStackJS.of(extracted);
                 })
-                .orElse(EmptyItemStackJS.INSTANCE);
+                .orElse(ItemStackJS.EMPTY);
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/common/util/Utils.java
+++ b/src/main/java/fr/frinn/custommachinery/common/util/Utils.java
@@ -166,7 +166,7 @@ public class Utils {
 
     public static boolean isResourceNameValid(String resourceLocation) {
         try {
-            ResourceLocation location = new ResourceLocation(resourceLocation);
+            new ResourceLocation(resourceLocation);
             return true;
         } catch (ResourceLocationException e) {
             return false;


### PR DESCRIPTION
This PR makes adding items/blocks from other mods(vanilla included) into catalysts possible, like this: 
<img width="197" alt="image" src="https://github.com/Frinn38/Custom-Machinery/assets/47418975/53349a7c-dad1-4fc5-87f6-0df8ef654c58">
It will be very useful for recipes that needs catalysts slots as additional info, like tiered crushers derived from modded crushers. 

For a given catalyst entry, it will first be compared with names from CustomMachinery itself, so that we can prevent this update from breaking existing scripts. 
If not matched, it will check names from item registry. 
If not matched again, a warning will be printed into `custommachinery.log` . It's not an error, because this is not fatal. 

There's also some cleanup and dependency updates. (Maybe I should put them somewhere else, like another PR)

