### PR TITLE
Non-Vanilla tags fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,13 @@ sourceSets {
     main{
         runtimeClasspath += sourceSets.api.output
         compileClasspath += sourceSets.api.output
-        ext.refMap = "main.refmap.json"
+        ext.refMap = "custommachinery.mixins.refmap.json"
     }
     test
+}
+
+mixin {
+    config "custommachinery.mixins.json"
 }
 
 configurations {
@@ -49,8 +53,7 @@ minecraft {
     // Simply re-run your setup task after changing the mappings to update your workspace.
     mappings channel: 'snapshot', version: '20210309-1.16.5'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
-    
-    // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+    accessTransformer(files('src/main/resources/META-INF/accesstransformer.cfg'))
 
     // Default run configurations.
     // These can be tweaked, removed, or duplicated as needed.
@@ -59,7 +62,7 @@ minecraft {
             workingDirectory project.file('run')
 
             // Recommended logging data for a userdev environment
-            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            property 'forge.logging.markers', 'REGISTRIES'
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
@@ -75,15 +78,13 @@ minecraft {
                     source sourceSets.api
                 }
             }
-
-            accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
         }
 
         client2 {
             workingDirectory project.file('run')
 
             // Recommended logging data for a userdev environment
-            //property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            property 'forge.logging.markers', 'REGISTRIES'
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
@@ -101,15 +102,13 @@ minecraft {
                     source sourceSets.api
                 }
             }
-
-            accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
         }
 
         server {
             workingDirectory project.file('run')
 
             // Recommended logging data for a userdev environment
-            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            property 'forge.logging.markers', 'REGISTRIES,REGISTRYDUMP'
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
@@ -125,8 +124,6 @@ minecraft {
                     source sourceSets.api
                 }
             }
-
-            accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
         }
 
         data {
@@ -147,8 +144,6 @@ minecraft {
                 }
             }
         }
-
-        accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
     }
 }
 
@@ -177,7 +172,7 @@ repositories {
         url = "https://maven.architectury.dev"
     }
     maven { //KubeJS/Rhino
-        url = "https://maven.saps.dev/minecraft"
+        url = "https://maven.latvian.dev/releases"
     }
     maven { //HyperLightning
         url = "https://maven.hypherionmc.me/releases"
@@ -188,7 +183,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.16.5-36.2.34'
+    minecraft 'net.minecraftforge:forge:1.16.5-36.2.42'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
@@ -212,18 +207,19 @@ dependencies {
     implementation fg.deobf("mezz.jei:jei-1.16.5:${jei_version}:api")
     runtimeOnly fg.deobf("mezz.jei:jei-1.16.5:${jei_version}")
     implementation fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.5:${ct_version}")
-    implementation fg.deobf("dev.latvian.mods:kubejs-forge:${kubejs_version}")
-    implementation fg.deobf("dev.latvian.mods:rhino-forge:${rhino_version}")
+    implementation fg.deobf("curse.maven:kubejs-238086:3647098")
+    implementation fg.deobf("curse.maven:rhino-416294:3525704")
     implementation fg.deobf("me.shedaniel:architectury-forge:${architectury_version}")
     implementation(fg.deobf("curse.maven:gadgets-298187:3498508"))
 
     runtimeOnly fg.deobf("mekanism:Mekanism:1.16.5-10.0.20.447")//Mekanism
     runtimeOnly fg.deobf("curse.maven:spark-361579:3337641")//Spark profiler
+    runtimeOnly fg.deobf("curse.maven:enablemultiplayermode-910522:4740559")
 
     //Jade
     implementation fg.deobf("curse.maven:jade-324717:3875132")
 
-    annotationProcessor "org.spongepowered:mixin:0.8.2:processor"
+    annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
 }
 
 def getManifestAttributes(String title) {

--- a/src/main/java/fr/frinn/custommachinery/CustomMachinery.java
+++ b/src/main/java/fr/frinn/custommachinery/CustomMachinery.java
@@ -11,21 +11,15 @@ import fr.frinn.custommachinery.common.init.CustomMachineTile;
 import fr.frinn.custommachinery.common.init.Registration;
 import fr.frinn.custommachinery.common.integration.buildinggadgets.BuildingGadgetsIntegration;
 import fr.frinn.custommachinery.common.integration.theoneprobe.TOPInfoProvider;
-import fr.frinn.custommachinery.common.network.NetworkManager;
-import fr.frinn.custommachinery.common.network.SLootTablesPacket;
-import fr.frinn.custommachinery.common.network.SUpdateMachinesPacket;
-import fr.frinn.custommachinery.common.network.SUpdateUpgradesPacket;
+import fr.frinn.custommachinery.common.network.*;
 import fr.frinn.custommachinery.common.util.CMLogger;
 import fr.frinn.custommachinery.common.util.LootTableHelper;
+import fr.frinn.custommachinery.common.util.TagIndex;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.AddReloadListenerEvent;
-import net.minecraftforge.event.CommandEvent;
-import net.minecraftforge.event.OnDatapackSyncEvent;
-import net.minecraftforge.event.RegisterCommandsEvent;
-import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.*;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.InterModComms;
@@ -42,10 +36,7 @@ import net.minecraftforge.fml.network.PacketDistributor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Mod(CustomMachinery.MODID)
 public class CustomMachinery {

--- a/src/main/java/fr/frinn/custommachinery/common/network/NetworkManager.java
+++ b/src/main/java/fr/frinn/custommachinery/common/network/NetworkManager.java
@@ -26,5 +26,6 @@ public class NetworkManager {
         CHANNEL.registerMessage(index++, SOpenFilePacket.class, SOpenFilePacket::encode, SOpenFilePacket::decode, SOpenFilePacket::handle);
         CHANNEL.registerMessage(index++, CGuiElementClickPacket.class, CGuiElementClickPacket::encode, CGuiElementClickPacket::decode, CGuiElementClickPacket::handle);
         CHANNEL.registerMessage(index++, SStructureCreatorPacket.class, SStructureCreatorPacket::encode, SStructureCreatorPacket::decode, SStructureCreatorPacket::handle);
+        CHANNEL.registerMessage(index++, SUpdateTagIndexPacket.class, SUpdateTagIndexPacket::encode, SUpdateTagIndexPacket::decode, SUpdateTagIndexPacket::handle);
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/common/network/SUpdateTagIndexPacket.java
+++ b/src/main/java/fr/frinn/custommachinery/common/network/SUpdateTagIndexPacket.java
@@ -1,0 +1,100 @@
+package fr.frinn.custommachinery.common.network;
+
+import fr.frinn.custommachinery.common.util.TagIndex;
+import net.minecraft.block.Block;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.Item;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.tags.ITag;
+import net.minecraft.tags.Tag;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.network.NetworkDirection;
+import net.minecraftforge.fml.network.NetworkEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import java.util.*;
+import java.util.function.Supplier;
+
+/**
+ * Purpose of this packet to populate TagIndex before recipes sync.
+ * Stupid mojang sending recipes first and than tags, like wtf??
+ * Also there's no event so early, so it's sent from mixin injections...
+ */
+public class SUpdateTagIndexPacket {
+    private final Map<ResourceLocation, ITag.INamedTag<Item>> itemTagIndex;
+    private final Map<ResourceLocation, ITag.INamedTag<Fluid>> fluidTagIndex;
+    private final Map<ResourceLocation, ITag.INamedTag<Block>> blockTagIndex;
+
+    public SUpdateTagIndexPacket(
+            Map<ResourceLocation, ITag.INamedTag<Item>> itemTagIndex,
+            Map<ResourceLocation, ITag.INamedTag<Fluid>> fluidTagIndex,
+            Map<ResourceLocation, ITag.INamedTag<Block>> blockTagIndex
+    ) {
+        this.itemTagIndex = new HashMap<>(itemTagIndex);
+        this.fluidTagIndex = new HashMap<>(fluidTagIndex);
+        this.blockTagIndex = new HashMap<>(blockTagIndex);
+    }
+
+    public static void encode(SUpdateTagIndexPacket pkt, PacketBuffer buf) {
+        writeTagIndex(buf, pkt.itemTagIndex);
+        writeTagIndex(buf, pkt.fluidTagIndex);
+        writeTagIndex(buf, pkt.blockTagIndex);
+    }
+
+    private static <V extends IForgeRegistryEntry<V>> void writeTagIndex(PacketBuffer buf, Map<ResourceLocation, ITag.INamedTag<V>> tagIndex) {
+        buf.writeInt(tagIndex.size());
+        tagIndex.entrySet().forEach(e -> writeTag(buf, e));
+    }
+
+    private static <V extends IForgeRegistryEntry<V>> void writeTag(PacketBuffer buf, Map.Entry<ResourceLocation, ITag.INamedTag<V>> tagEntry) {
+        buf.writeResourceLocation(tagEntry.getKey());
+        List<V> items = tagEntry.getValue().getAllElements();
+        buf.writeInt(items.size());
+        for (V item : items) {
+            buf.writeResourceLocation(item.getRegistryName());
+        }
+    }
+
+    public static SUpdateTagIndexPacket decode(PacketBuffer buf) {
+        Map<ResourceLocation, ITag.INamedTag<Item>> itemTagIndex = readTagIndex(buf, ForgeRegistries.ITEMS);
+        Map<ResourceLocation, ITag.INamedTag<Fluid>> fluidTagIndex = readTagIndex(buf, ForgeRegistries.FLUIDS);
+        Map<ResourceLocation, ITag.INamedTag<Block>> blockTagIndex = readTagIndex(buf, ForgeRegistries.BLOCKS);
+        return new SUpdateTagIndexPacket(itemTagIndex, fluidTagIndex, blockTagIndex);
+    }
+
+    public static <V extends IForgeRegistryEntry<V>> Map<ResourceLocation, ITag.INamedTag<V>> readTagIndex(PacketBuffer buf, IForgeRegistry<V> registry) {
+        Map<ResourceLocation, ITag.INamedTag<V>> tagIndex = new HashMap<>();
+        int size = buf.readInt();
+        for (int i = 0; i < size; i++) {
+            ITag.INamedTag<V> tag = readTag(buf, registry);
+            tagIndex.put(tag.getName(), tag);
+        }
+        return tagIndex;
+    }
+
+    public static <V extends IForgeRegistryEntry<V>> ITag.INamedTag<V> readTag(PacketBuffer buf, IForgeRegistry<V> registry) {
+        ResourceLocation tagName = buf.readResourceLocation();
+        int size = buf.readInt();
+        Set<V> tagContent = new HashSet<>();
+        for (int i = 0; i < size; i++) {
+            ResourceLocation contentId = buf.readResourceLocation();
+            V value = registry.getValue(contentId);
+            tagContent.add(value);
+        }
+        ITag<V> tag = Tag.getTagFromContents(tagContent);
+        return TagIndex.nameTag(tagName, tag);
+    }
+
+    public void handle(Supplier<NetworkEvent.Context> context) {
+        if(context.get().getDirection() == NetworkDirection.PLAY_TO_CLIENT) {
+            context.get().enqueueWork(() -> {
+                TagIndex.setNewTagIndex(itemTagIndex, "item");
+                TagIndex.setNewTagIndex(fluidTagIndex, "fluid");
+                TagIndex.setNewTagIndex(blockTagIndex, "block");
+            });
+        }
+        context.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/fr/frinn/custommachinery/common/util/Codecs.java
+++ b/src/main/java/fr/frinn/custommachinery/common/util/Codecs.java
@@ -97,9 +97,9 @@ public class Codecs {
 
     public static final Codec<ComparatorMode> COMPARATOR_MODE_CODEC         = CodecLogger.namedCodec(Codec.STRING.comapFlatMap(Codecs::decodeComparatorMode, ComparatorMode::getPrefix), "Comparator Mode");
 
-    public static final Codec<ITag<Item>> ITEM_TAG_CODEC   = CodecLogger.namedCodec(tagCodec(Utils::getItemTag, Utils::getItemTagID), "Item Tag");
-    public static final Codec<ITag<Fluid>> FLUID_TAG_CODEC = CodecLogger.namedCodec(tagCodec(Utils::getFluidTag, Utils::getFluidTagID), "Fluid Tag");
-    public static final Codec<ITag<Block>> BLOCK_TAG_CODEC = CodecLogger.namedCodec(tagCodec(Utils::getBlockTag, Utils::getBlockTagID), "Block Tag");
+    public static final Codec<ITag.INamedTag<Item>> ITEM_TAG_CODEC   = CodecLogger.namedCodec(namedTagCodec(TagIndex::getItemTag, TagIndex::getItemTagID), "Item Tag");
+    public static final Codec<ITag.INamedTag<Fluid>> FLUID_TAG_CODEC = CodecLogger.namedCodec(namedTagCodec(TagIndex::getFluidTag, TagIndex::getFluidTagID), "Fluid Tag");
+    public static final Codec<ITag.INamedTag<Block>> BLOCK_TAG_CODEC = CodecLogger.namedCodec(namedTagCodec(TagIndex::getBlockTag, TagIndex::getBlockTagID), "Block Tag");
 
     public static final Codec<MachineStatus> STATUS_CODEC                               = fromEnum(MachineStatus.class);
     public static final Codec<ComponentIOMode> COMPONENT_MODE_CODEC                     = fromEnum(ComponentIOMode.class);
@@ -155,13 +155,13 @@ public class Codecs {
         return new EnhancedListCodec<>(codec);
     }
 
-    public static <E> Codec<ITag<E>> tagCodec(Function<ResourceLocation, ITag<E>> tagGetter, Function<ITag<E>, ResourceLocation> idGetter) {
+    public static <E> Codec<ITag.INamedTag<E>> namedTagCodec(Function<ResourceLocation, ITag.INamedTag<E>> tagGetter, Function<ITag.INamedTag<E>, ResourceLocation> idGetter) {
         return Codec.STRING.comapFlatMap(string -> {
             if(string.startsWith("#"))
                 string = string.substring(1);
             if(!Utils.isResourceNameValid(string))
                 return DataResult.error(String.format("Invalid tag : %s is not a valid tag id !", string));
-            ITag<E> tag = tagGetter.apply(new ResourceLocation(string));
+            ITag.INamedTag<E> tag = tagGetter.apply(new ResourceLocation(string));
             if(tag == null)
                 return DataResult.error("Unknown tag : " + string);
             return DataResult.success(tag);

--- a/src/main/java/fr/frinn/custommachinery/common/util/TagIndex.java
+++ b/src/main/java/fr/frinn/custommachinery/common/util/TagIndex.java
@@ -1,0 +1,134 @@
+package fr.frinn.custommachinery.common.util;
+
+import fr.frinn.custommachinery.common.network.SUpdateTagIndexPacket;
+import net.minecraft.block.Block;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.Item;
+import net.minecraft.tags.*;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TagIndex {
+
+    public static ResourceLocation getItemTagID(ITag.INamedTag<Item> tag) {
+        return tag.getName();
+    }
+
+    public static ResourceLocation getFluidTagID(ITag.INamedTag<Fluid> tag) {
+        return tag.getName();
+    }
+
+    public static ResourceLocation getBlockTagID(ITag.INamedTag<Block> tag) {
+        return tag.getName();
+    }
+
+    public static ITag.INamedTag<Item> getItemTag(ResourceLocation loc) {
+        ITag<Item> genericTag = itemTagIndex.get(loc);
+        genericTag = genericTag != null ? genericTag : ItemTags.getCollection().get(loc);
+        if (genericTag == null) return null;
+        return new DelegatedNamedTag<>(loc, genericTag);
+    }
+
+    public static ITag.INamedTag<Fluid> getFluidTag(ResourceLocation loc) {
+        ITag<Fluid> genericTag = fluidTagIndex.get(loc);
+        genericTag = genericTag != null ? genericTag : FluidTags.getCollection().get(loc);
+        if (genericTag == null) return null;
+        return new DelegatedNamedTag<>(loc, genericTag);
+    }
+
+    public static ITag.INamedTag<Block> getBlockTag(ResourceLocation loc) {
+        ITag<Block> genericTag = blockTagIndex.get(loc);
+        genericTag = genericTag != null ? genericTag : BlockTags.getCollection().get(loc);
+        if (genericTag == null) return null;
+        return new DelegatedNamedTag<>(loc, genericTag);
+    }
+
+    private static Map<ResourceLocation, ITag.INamedTag<Item>> itemTagIndex = new HashMap<>();
+    private static Map<ResourceLocation, ITag.INamedTag<Fluid>> fluidTagIndex = new HashMap<>();
+    private static Map<ResourceLocation, ITag.INamedTag<Block>> blockTagIndex = new HashMap<>();
+
+    public static SUpdateTagIndexPacket createUpdatePacket() {
+        return new SUpdateTagIndexPacket(itemTagIndex, fluidTagIndex, blockTagIndex);
+    }
+
+    public static <T extends ITag<V>, V> void setNewTagIndex(Map<ResourceLocation, T> tagMap, String tagType) {
+        switch (tagType) {
+            case "item":
+                itemTagIndex = unsafeCast(wrapWithDelegates(tagMap));
+                break;
+            case "fluid":
+                fluidTagIndex = unsafeCast(wrapWithDelegates(tagMap));
+                break;
+            case "block":
+                blockTagIndex = unsafeCast(wrapWithDelegates(tagMap));
+                break;
+        }
+    }
+
+    private static <T extends ITag<V>, V> Map<ResourceLocation, ITag.INamedTag<V>> wrapWithDelegates(Map<ResourceLocation, T> tagMap) {
+        return tagMap.entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> new DelegatedNamedTag<>(
+                        entry.getKey(),
+                        entry.getValue()
+                )
+        ));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T, R> R unsafeCast(T t) {
+        return (R) t;
+    }
+
+    public static <T> ITag.INamedTag<T> nameTag(ResourceLocation name, ITag<T> tag) {
+        return new DelegatedNamedTag<>(name, tag);
+    }
+
+    private static class DelegatedNamedTag<T> implements ITag.INamedTag<T> {
+
+        private final ResourceLocation name;
+        private final ITag<T> delegate;
+
+        public DelegatedNamedTag(ResourceLocation name, ITag<T> delegate) {
+            if (delegate == null)
+                throw new NullPointerException("DelegatedNamedTag: delegate == null");
+            this.name = name;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean contains(T element) {
+            return delegate.contains(element);
+        }
+
+        @Override
+        public List<T> getAllElements() {
+            return delegate.getAllElements();
+        }
+
+        @Override
+        public ResourceLocation getName() {
+            return name;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public boolean equals(Object obj) {
+            if (!(obj instanceof INamedTag)) return false;
+            INamedTag<T> tag = (INamedTag<T>) obj;
+            return delegate.equals(tag);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return name.toString();
+        }
+    }
+}

--- a/src/main/java/fr/frinn/custommachinery/common/util/Utils.java
+++ b/src/main/java/fr/frinn/custommachinery/common/util/Utils.java
@@ -9,11 +9,9 @@ import fr.frinn.custommachinery.common.data.upgrade.RecipeModifier;
 import fr.frinn.custommachinery.common.init.CustomMachineTile;
 import fr.frinn.custommachinery.common.init.Registration;
 import fr.frinn.custommachinery.common.util.ingredient.IIngredient;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.fluid.Fluid;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.TieredItem;
@@ -33,9 +31,7 @@ import net.minecraft.nbt.ShortNBT;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.EffectUtils;
 import net.minecraft.potion.Effects;
-import net.minecraft.tags.FluidTags;
-import net.minecraft.tags.ITag;
-import net.minecraft.tags.TagCollectionManager;
+import net.minecraft.tags.*;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.ResourceLocationException;
@@ -48,10 +44,7 @@ import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.event.ForgeEventFactory;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -62,30 +55,6 @@ public class Utils {
 
     public static boolean canPlayerManageMachines(PlayerEntity player) {
         return player.hasPermissionLevel(Objects.requireNonNull(player.getServer()).getOpPermissionLevel());
-    }
-
-    public static ResourceLocation getItemTagID(ITag<Item> tag) {
-        return TagCollectionManager.getManager().getItemTags().getValidatedIdFromTag(tag);
-    }
-
-    public static ResourceLocation getFluidTagID(ITag<Fluid> tag) {
-        return TagCollectionManager.getManager().getFluidTags().getValidatedIdFromTag(tag);
-    }
-
-    public static ResourceLocation getBlockTagID(ITag<Block> tag) {
-        return TagCollectionManager.getManager().getBlockTags().getValidatedIdFromTag(tag);
-    }
-
-    public static ITag<Item> getItemTag(ResourceLocation loc) {
-        return TagCollectionManager.getManager().getItemTags().get(loc);
-    }
-
-    public static ITag<Fluid> getFluidTag(ResourceLocation loc) {
-        return TagCollectionManager.getManager().getFluidTags().get(loc);
-    }
-
-    public static ITag<Block> getBlockTag(ResourceLocation loc) {
-        return TagCollectionManager.getManager().getBlockTags().get(loc);
     }
 
     public static Vector3d vec3dFromBlockPos(BlockPos pos) {

--- a/src/main/java/fr/frinn/custommachinery/common/util/ingredient/BlockTagIngredient.java
+++ b/src/main/java/fr/frinn/custommachinery/common/util/ingredient/BlockTagIngredient.java
@@ -4,9 +4,9 @@ import com.google.common.collect.ImmutableList;
 import com.mojang.serialization.Codec;
 import fr.frinn.custommachinery.common.util.Codecs;
 import fr.frinn.custommachinery.common.util.PartialBlockState;
+import fr.frinn.custommachinery.common.util.TagIndex;
 import net.minecraft.block.Block;
 import net.minecraft.tags.ITag;
-import net.minecraft.tags.TagCollectionManager;
 import net.minecraftforge.common.util.Lazy;
 
 import java.util.List;
@@ -16,10 +16,10 @@ public class BlockTagIngredient implements IIngredient<PartialBlockState> {
 
     public static final Codec<BlockTagIngredient> CODEC = Codecs.BLOCK_TAG_CODEC.xmap(BlockTagIngredient::new, ingredient -> ingredient.tag);
 
-    private ITag<Block> tag;
-    private Lazy<List<PartialBlockState>> ingredients;
+    private final ITag.INamedTag<Block> tag;
+    private final Lazy<List<PartialBlockState>> ingredients;
 
-    public BlockTagIngredient(ITag<Block> tag) {
+    public BlockTagIngredient(ITag.INamedTag<Block> tag) {
         this.tag = tag;
         this.ingredients = Lazy.of(() -> tag.getAllElements().stream().map(PartialBlockState::new).collect(Collectors.collectingAndThen(Collectors.toList(), ImmutableList::copyOf)));
     }
@@ -36,6 +36,6 @@ public class BlockTagIngredient implements IIngredient<PartialBlockState> {
 
     @Override
     public String toString() {
-        return "#" + TagCollectionManager.getManager().getBlockTags().getDirectIdFromTag(this.tag);
+        return "#" + TagIndex.getBlockTagID(this.tag);
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/common/util/ingredient/FluidTagIngredient.java
+++ b/src/main/java/fr/frinn/custommachinery/common/util/ingredient/FluidTagIngredient.java
@@ -3,10 +3,10 @@ package fr.frinn.custommachinery.common.util.ingredient;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import fr.frinn.custommachinery.common.util.Codecs;
+import fr.frinn.custommachinery.common.util.TagIndex;
 import fr.frinn.custommachinery.common.util.Utils;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.tags.ITag;
-import net.minecraft.tags.TagCollectionManager;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.List;
@@ -19,9 +19,9 @@ public class FluidTagIngredient implements IIngredient<Fluid> {
     public static final Codec<FluidTagIngredient> CODEC = Codecs.either(CODEC_FOR_DATAPACK, CODEC_FOR_KUBEJS, "Fluid Tag Ingredient")
             .xmap(either -> either.map(Function.identity(), Function.identity()), Either::left);
 
-    private ITag<Fluid> tag;
+    private final ITag.INamedTag<Fluid> tag;
 
-    public FluidTagIngredient(ITag<Fluid> tag) {
+    public FluidTagIngredient(ITag.INamedTag<Fluid> tag) {
         this.tag = tag;
     }
 
@@ -30,14 +30,14 @@ public class FluidTagIngredient implements IIngredient<Fluid> {
             s = s.substring(1);
         if(!Utils.isResourceNameValid(s))
             throw new IllegalArgumentException(String.format("Invalid tag id : %s", s));
-        ITag<Fluid> tag = TagCollectionManager.getManager().getFluidTags().get(new ResourceLocation(s));
+        ITag.INamedTag<Fluid> tag = TagIndex.getFluidTag(new ResourceLocation(s));
         if(tag == null)
             throw new IllegalArgumentException(String.format("Tag: %s does not exist", s));
         return new FluidTagIngredient(tag);
     }
 
     public static FluidTagIngredient create(ResourceLocation loc) throws IllegalArgumentException {
-        ITag<Fluid> tag = TagCollectionManager.getManager().getFluidTags().get(loc);
+        ITag.INamedTag<Fluid> tag = TagIndex.getFluidTag(loc);
         if(tag == null)
             throw new IllegalArgumentException(String.format("Tag: %s does not exist", loc));
         return new FluidTagIngredient(tag);
@@ -55,6 +55,6 @@ public class FluidTagIngredient implements IIngredient<Fluid> {
 
     @Override
     public String toString() {
-        return "#" + TagCollectionManager.getManager().getFluidTags().getDirectIdFromTag(this.tag);
+        return "#" + TagIndex.getFluidTagID(this.tag);
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/common/util/ingredient/ItemTagIngredient.java
+++ b/src/main/java/fr/frinn/custommachinery/common/util/ingredient/ItemTagIngredient.java
@@ -3,10 +3,10 @@ package fr.frinn.custommachinery.common.util.ingredient;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import fr.frinn.custommachinery.common.util.Codecs;
+import fr.frinn.custommachinery.common.util.TagIndex;
 import fr.frinn.custommachinery.common.util.Utils;
 import net.minecraft.item.Item;
 import net.minecraft.tags.ITag;
-import net.minecraft.tags.TagCollectionManager;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.List;
@@ -19,9 +19,9 @@ public class ItemTagIngredient implements IIngredient<Item> {
     public static final Codec<ItemTagIngredient> CODEC = Codecs.either(CODEC_FOR_DATAPACK, CODEC_FOR_KUBEJS, "Item Tag Ingredient")
             .xmap(either -> either.map(Function.identity(), Function.identity()), Either::left);
 
-    private ITag<Item> tag;
+    private final ITag.INamedTag<Item> tag;
 
-    public ItemTagIngredient(ITag<Item> tag) {
+    public ItemTagIngredient(ITag.INamedTag<Item> tag) {
         this.tag = tag;
     }
 
@@ -30,14 +30,14 @@ public class ItemTagIngredient implements IIngredient<Item> {
             s = s.substring(1);
         if(!Utils.isResourceNameValid(s))
             throw new IllegalArgumentException(String.format("Invalid tag id : %s", s));
-        ITag<Item> tag = TagCollectionManager.getManager().getItemTags().get(new ResourceLocation(s));
+        ITag.INamedTag<Item> tag = TagIndex.getItemTag(new ResourceLocation(s));
         if(tag == null)
             throw new IllegalArgumentException(String.format("Tag: %s does not exist", s));
         return new ItemTagIngredient(tag);
     }
 
     public static ItemTagIngredient create(ResourceLocation loc) throws IllegalArgumentException {
-        ITag<Item> tag = TagCollectionManager.getManager().getItemTags().get(loc);
+        ITag.INamedTag<Item> tag = TagIndex.getItemTag(loc);
         if(tag == null)
             throw new IllegalArgumentException(String.format("Tag: %s does not exist", loc));
         return new ItemTagIngredient(tag);
@@ -55,6 +55,6 @@ public class ItemTagIngredient implements IIngredient<Item> {
 
     @Override
     public String toString() {
-        return "#" + TagCollectionManager.getManager().getItemTags().getDirectIdFromTag(this.tag);
+        return "#" + TagIndex.getItemTagID(this.tag);
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/mixin/PlayerListMixin.java
+++ b/src/main/java/fr/frinn/custommachinery/mixin/PlayerListMixin.java
@@ -1,0 +1,19 @@
+package fr.frinn.custommachinery.mixin;
+
+import fr.frinn.custommachinery.common.network.NetworkManager;
+import fr.frinn.custommachinery.common.util.TagIndex;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.server.management.PlayerList;
+import net.minecraftforge.fml.network.PacketDistributor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = PlayerList.class)
+public abstract class PlayerListMixin {
+    @Inject(method = "initializeConnectionToPlayer", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/network/NetworkHooks;sendMCRegistryPackets(Lnet/minecraft/network/NetworkManager;Ljava/lang/String;)V", shift = At.Shift.AFTER, remap = false))
+    private void sendTags(net.minecraft.network.NetworkManager netManager, ServerPlayerEntity playerIn, CallbackInfo ci) {
+        NetworkManager.CHANNEL.send(PacketDistributor.PLAYER.with(() -> playerIn), TagIndex.createUpdatePacket());
+    }
+}

--- a/src/main/java/fr/frinn/custommachinery/mixin/TagCollectionReaderMixin.java
+++ b/src/main/java/fr/frinn/custommachinery/mixin/TagCollectionReaderMixin.java
@@ -1,0 +1,29 @@
+package fr.frinn.custommachinery.mixin;
+
+import fr.frinn.custommachinery.common.util.TagIndex;
+import net.minecraft.tags.ITag;
+import net.minecraft.tags.ITagCollection;
+import net.minecraft.tags.TagCollectionReader;
+import net.minecraft.util.ResourceLocation;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Map;
+
+@Mixin(value = TagCollectionReader.class)
+public abstract class TagCollectionReaderMixin<T> {
+
+    @Shadow
+    @Final
+    private String tagType;
+
+    @Redirect(method = "buildTagCollectionFromMap", at = @At(value = "INVOKE", target = "Lnet/minecraft/tags/ITagCollection;getTagCollectionFromMap(Ljava/util/Map;)Lnet/minecraft/tags/ITagCollection;"))
+    private ITagCollection<T> fillTagIndex(Map<ResourceLocation, ITag<T>> finalTagMap) {
+        TagIndex.setNewTagIndex(finalTagMap, tagType);
+        return ITagCollection.getTagCollectionFromMap(finalTagMap);
+    }
+
+}

--- a/src/main/resources/custommachinery.mixins.json
+++ b/src/main/resources/custommachinery.mixins.json
@@ -2,8 +2,13 @@
   "required": true,
   "minVersion": "0.8",
   "package": "fr.frinn.custommachinery.mixin",
+  "refmap": "custommachinery.mixins.refmap.json",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "PlayerListMixin",
+    "TagCollectionReaderMixin"
+  ],
+  "server": [
   ],
   "client": [
   ],


### PR DESCRIPTION
This PR introduces class TagIndex to index and query tags avoiding invalid Mojang/Forge system. Mixin needed to send tags earlier than recipes, as there's no events so early (mojang somehow done it wrong and send recipes before tags). Also ITag usages were refactored into INamedTag to simplify abstraction and TagIndex