### PR TITLE
Allow tooltips to render in JEI

### DIFF
--- a/src/main/java/fr/frinn/custommachinery/api/integration/jei/IJEIElementRenderer.java
+++ b/src/main/java/fr/frinn/custommachinery/api/integration/jei/IJEIElementRenderer.java
@@ -32,6 +32,6 @@ public interface IJEIElementRenderer<T extends IGuiElement> {
      * @return A list of text components that will be displayed as tooltips when the mouse cursor hover the gui element.
      */
     default List<Component> getJEITooltips(T element, IMachineRecipe recipe) {
-        return Collections.emptyList();
+        return element.getTooltips();
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/client/integration/jei/element/FuelGuiElementJeiRenderer.java
+++ b/src/main/java/fr/frinn/custommachinery/client/integration/jei/element/FuelGuiElementJeiRenderer.java
@@ -9,6 +9,7 @@ import fr.frinn.custommachinery.common.requirement.FuelRequirement;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -23,8 +24,9 @@ public class FuelGuiElementJeiRenderer implements IJEIElementRenderer<FuelGuiEle
     @Override
     public List<Component> getJEITooltips(FuelGuiElement element, IMachineRecipe recipe) {
         int amount = recipe.getRequirements().stream().filter(requirement -> requirement.requirement() instanceof FuelRequirement).findFirst().map(requirement -> ((FuelRequirement)requirement.requirement()).amount()).orElse(0);
+        List<Component> tooltips = new ArrayList<>(element.getTooltips());
         if(amount > 0)
-            return Lists.newArrayList(Component.translatable("custommachinery.jei.ingredient.fuel.amount", amount));
-        return Collections.emptyList();
+            tooltips.add(Component.translatable("custommachinery.jei.ingredient.fuel.amount", amount));
+        return tooltips;
     }
 }

--- a/src/main/java/fr/frinn/custommachinery/client/integration/jei/element/ProgressGuiElementJeiRenderer.java
+++ b/src/main/java/fr/frinn/custommachinery/client/integration/jei/element/ProgressGuiElementJeiRenderer.java
@@ -22,7 +22,7 @@ public class ProgressGuiElementJeiRenderer implements IJEIElementRenderer<Progre
 
     @Override
     public List<Component> getJEITooltips(ProgressBarGuiElement element, IMachineRecipe recipe) {
-        List<Component> tooltips = new ArrayList<>();
+        List<Component> tooltips = new ArrayList<>(element.getTooltips());
         if(recipe.getRecipeTime() > 0)
             tooltips.add(Component.translatable("custommachinery.jei.recipe.time", recipe.getRecipeTime()));
         else


### PR DESCRIPTION
Allows tooltips to show in JEI.

Elements with default tooltips (Such as the progress bar) will append them to the end of the user-specified tooltips.